### PR TITLE
Change `Parser` interface slightly

### DIFF
--- a/smt-log-parser/src/main.rs
+++ b/smt-log-parser/src/main.rs
@@ -34,7 +34,7 @@ fn main() {
         let (timeout, _result) = parser.process_all_timeout(to);
         let elapsed_time = time.elapsed();
         println!(
-            "Finished parsing after {} seconds (timeout {timeout})\n",
+            "Finished parsing after {} seconds (timeout {timeout:?})\n",
             elapsed_time.as_secs_f32()
         );
         // result.save_output_to_files(&settings, &time);

--- a/smt-log-parser/src/parsers/mod.rs
+++ b/smt-log-parser/src/parsers/mod.rs
@@ -10,39 +10,48 @@ pub use self::wrapper_async_parser::*;
 
 pub mod z3;
 
-/// Trait for a generic SMT solver trace parser. Intended to support different solvers or log formats.
+/// Trait for a generic SMT solver trace parser. Intended to support different
+/// solvers or log formats.
 pub trait LogParser: Default + Debug {
+    /// Process a single line of the log file. Return `true` if parsing should
+    /// continue, or `false` if parsing should stop.
     fn process_line(&mut self, line: &str, line_no: usize) -> bool;
 
     /// Creates a new parser. Only use this if you cannot use the following
     /// convenience methods:
     /// - [`new_file`] for creating a streaming parser from a file path
-    /// - [`new_str`] for creating a parser from a strings
-    ///
-    /// The provided `end_data` will be seen with each callback to `stop` in
-    /// [`process_until`].
+    /// - [`new_str`] or [`new_string`] for creating a parser from a strings
     fn from<'r, R: BufRead + 'r>(reader: R) -> StreamParser<'r, Self> {
         StreamParser::new(reader)
     }
+    /// Creates a new async parser from an async buffered reader. The parser
+    /// will read rom the reader line-by-line.
     fn from_async<'r, R: AsyncBufRead + Unpin + 'r>(reader: R) -> AsyncParser<'r, Self> {
         AsyncParser::new(reader)
     }
 
-    /// Creates a new parser from the contents of a log file.
+    /// Creates a new parser from the contents of a log file. The string
+    /// argument must live as long as parsing is ongoing. Release this
+    /// constraint by using [`take_parser`](StreamParser::take_parser) to end
+    /// parsing. If you want the parser to take ownership of the string instead
+    /// (i.e. you are running into lifetime issues), use
+    /// [`from_string`](Self::from_string) instead.
     fn from_str<'r>(s: &'r str) -> StreamParser<'r, Self> {
         s.as_bytes().into_parser()
     }
-    /// Creates a new parser from the contents of a log file.
+    /// Creates a new parser from the contents of a log file. The parser takes
+    /// ownership over the string.
     fn from_string(s: String) -> StreamParser<'static, Self> {
         s.into_cursor().into_parser()
     }
 
-    /// Creates a new streaming parser from a file. The `end_data` is the total
-    /// number of bytes in the file.
+    /// Creates a new streaming parser from a file. Additionally returns the
+    /// file metadata so that the progress can be calculated from the file size.
     ///
-    /// This method is an alternative to `from_string(fs::read_to_string(self)?)`.
-    /// This approach to parsing is ~5% slower, but should use only ~50% as much
-    /// memory due to not having the entire loaded String in memory.
+    /// This method is an alternative to
+    /// `from_string(fs::read_to_string(self)?)`. This approach to parsing is
+    /// ~5% slower, but should use only ~50% as much memory due to not having
+    /// the entire loaded String in memory.
     fn from_file<P: AsRef<Path>>(
         p: P,
     ) -> Result<(Metadata, StreamParser<'static, Self>)> {
@@ -56,7 +65,7 @@ pub trait LogParser: Default + Debug {
 ////////////////////
 
 pub trait IntoStreamParser<'r> {
-    /// TODO: doc
+    /// Creates a new parser from a buffered reader.
     fn into_parser<Parser: LogParser>(self) -> StreamParser<'r, Parser>;
 }
 impl<'r, R: BufRead + 'r> IntoStreamParser<'r> for R {
@@ -66,9 +75,10 @@ impl<'r, R: BufRead + 'r> IntoStreamParser<'r> for R {
 }
 
 pub trait CursorRead: AsRef<[u8]> + Sized {
-    /// Turns any `[u8]` data such as a [`String`] into
-    /// a [`Cursor`](std::io::Cursor) which implements [`BufRead`](std::io::BufRead).
-    /// Intended to be chained with [`into_parser`](IntoStreamParser::into_parser).
+    /// Turns any `[u8]` data such as a [`String`] into a
+    /// [`Cursor`](std::io::Cursor) which implements
+    /// [`BufRead`](std::io::BufRead). Intended to be chained with
+    /// [`into_parser`](IntoStreamParser::into_parser).
     fn into_cursor(self) -> std::io::Cursor<Self> {
         std::io::Cursor::new(self)
     }
@@ -76,6 +86,9 @@ pub trait CursorRead: AsRef<[u8]> + Sized {
 impl<T: AsRef<[u8]>> CursorRead for T {}
 
 pub trait FileRead: AsRef<Path> + Sized {
+    /// Opens a file and returns a buffered reader and the file's metadata. A
+    /// more memory efficient alternative to
+    /// `fs::read_to_string(self)?.into_cursor()`.
     fn read_open(self) -> Result<(Metadata, BufReader<File>)> {
         let file = File::open(self)?;
         let metadata = file.metadata()?;
@@ -86,7 +99,7 @@ pub trait FileRead: AsRef<Path> + Sized {
 impl<T: AsRef<Path>> FileRead for T {}
 
 pub trait IntoAsyncParser<'r> {
-    /// TODO: doc
+    /// Creates a new parser from an async buffered reader.
     fn into_async_parser<Parser: LogParser>(self) -> AsyncParser<'r, Parser>;
 }
 impl<'r, R: AsyncBufRead + Unpin + 'r> IntoAsyncParser<'r> for R {
@@ -98,6 +111,10 @@ impl<'r, R: AsyncBufRead + Unpin + 'r> IntoAsyncParser<'r> for R {
 }
 
 pub trait AsyncBufferRead: AsyncRead + Sized {
+    /// Buffers any [`AsyncRead`](futures::io::AsyncRead) stream into a
+    /// [`BufAsyncRead`](futures::io::BufReader) stream. Do not use this if the
+    /// underlying stream already implements
+    /// [`BufAsyncRead`](futures::io::BufReader).
     fn buffer(self) -> futures::io::BufReader<Self> {
         futures::io::BufReader::new(self)
     }
@@ -105,6 +122,10 @@ pub trait AsyncBufferRead: AsyncRead + Sized {
 impl<T: AsyncRead> AsyncBufferRead for T {}
 
 pub trait AsyncCursorRead: AsRef<[u8]> + Unpin + Sized {
+    /// Turns any `[u8]` data such as a [`String`] into a async
+    /// [`Cursor`](futures::io::Cursor) which implements
+    /// [`AsyncBufRead`](futures::io::AsyncBufRead). Intended to be chained with
+    /// [`into_async_parser`](IntoAsyncParser::into_async_parser).
     fn into_async_cursor(self) -> futures::io::Cursor<Self> {
         futures::io::Cursor::new(self)
     }
@@ -115,6 +136,7 @@ impl<T: AsRef<[u8]> + Unpin> AsyncCursorRead for T {}
 // Parser Execution
 ////////////////////
 
+/// Progress information for a parser.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct ReaderState {
     /// The number of bytes parsed so far.
@@ -124,21 +146,24 @@ pub struct ReaderState {
 }
 
 #[duplicate::duplicate_item(
-    EitherParser   ReadBound              async   add_await(code);
+    EitherParser   ReadBound                   async   add_await(code);
     [StreamParser] [BufRead + 'r]              []      [code];
     [AsyncParser]  [AsyncBufRead + Unpin + 'r] [async] [code.await];
 )]
 mod wrapper {
     use super::*;
 
-    /// Struct for a generic SMT solver trace parser. Supports parsing line-by-line with a callback to
-    /// indicate if or when to pause. Intended to support different solvers or log formats.
-    pub struct EitherParser<'r, P: LogParser> {
-        reader: Box<dyn ReadBound>,
+    /// Struct which contains both a parser state as well as the stream of lines
+    /// which are being parsed. Always use this instead of the raw underlying
+    /// parser. Feeds the parser line-by-line with a callback to indicate if or
+    /// when to pause. Supports any parser as long as it implements
+    /// [`LogParser`].
+    pub struct EitherParser<'r, Parser: LogParser> {
+        reader: Option<Box<dyn ReadBound>>,
         reader_state: ReaderState,
-        parser: Option<P>,
+        parser: Parser,
     }
-    impl<'r, P: LogParser, R: ReadBound> From<R> for EitherParser<'r, P> {
+    impl<'r, Parser: LogParser, R: ReadBound> From<R> for EitherParser<'r, Parser> {
         fn from(reader: R) -> Self {
             Self::new(reader)
         }
@@ -146,67 +171,157 @@ mod wrapper {
     impl<'r, Parser: LogParser> EitherParser<'r, Parser> {
         pub(super) fn new(reader: impl ReadBound) -> Self {
             Self {
-                reader: Box::new(reader),
+                reader: Some(Box::new(reader)),
                 reader_state: ReaderState::default(),
-                parser: Some(Parser::default()),
+                parser: Parser::default(),
             }
         }
 
-        pub fn parser(&self) -> Option<&Parser> {
-            self.parser.as_ref()
+        /// Get the current parser state.
+        pub fn parser(&self) -> &Parser {
+            &self.parser
         }
-        pub fn reader_state(&self) -> &ReaderState {
-            &self.reader_state
+        /// Get the current parser state.
+        pub fn take_parser(self) -> Parser {
+            self.parser
         }
-        pub async fn process_until<'a>(
-            &'a mut self,
-            stop: impl Fn(&Parser, &ReaderState) -> bool,
-        ) -> Option<Parser> {
-            let Some(parser) = self.parser.as_mut() else {
+        /// Get the current reader progress.
+        pub fn reader_state(&self) -> ReaderState {
+            self.reader_state
+        }
+        /// Have we finished parsing?
+        pub fn is_done(&self) -> bool {
+            self.reader.is_none()
+        }
+        /// Parse the the input while calling the `predicate` callback after
+        /// each line. Keep parsing until the callback returns `false` or we
+        /// reach the end of the input. If we stopped due to the callback,
+        /// return the current progress as `Some`. Otherwise, if we are at the
+        /// end, return `None`. After this function returns, use
+        /// [`parser`](Self::parser) to retrieve the parser state.
+        /// 
+        /// The `predicate` callback should aim to return quickly since **it is
+        /// called between each line!** If heavier processing is required
+        /// consider using [`process_check_every`] or doing it under a
+        /// `reader_state.lines_read % LINES_PER_CHECK == 0` condition instead.
+        pub async fn process_until(
+            &mut self,
+            mut predicate: impl FnMut(&Parser, ReaderState) -> bool,
+        ) -> Option<ReaderState> {
+            let Some(reader) = self.reader.as_mut() else {
                 return None;
             };
             let mut buffer = String::new();
-            while !stop(&*parser, &self.reader_state) {
+            while predicate(&self.parser, self.reader_state) {
                 buffer.clear();
-                let bytes_read = add_await([self.reader.read_line(&mut buffer)]).unwrap();
+                let bytes_read = add_await([reader.read_line(&mut buffer)]).unwrap();
                 if bytes_read == 0
-                    || !parser
+                    || !self
+                        .parser
                         .process_line(buffer.trim_end(), self.reader_state.lines_read)
                 {
-                    return self.parser.take();
+                    let reader = self.reader.take();
+                    drop(reader); // Release file handle/free up memory
+                    return None;
                 }
                 self.reader_state.bytes_read += bytes_read;
                 self.reader_state.lines_read += 1;
             }
-            None
+            Some(self.reader_state)
         }
-        pub async fn process_for<'a>(
-            &'a mut self,
-            time: Duration,
-        ) -> Option<Parser> {
-            // Will actually process for up to (ms_per_line * 100)% longer than `time`, thus
-            // we are assuming that we can process lines faster than 0.1ms per line.
-            let check_freq = time.as_millis().try_into().unwrap_or(usize::MAX);
-            let start = Instant::now();
-            add_await([self.process_until(|_, state| {
-                state.lines_read % check_freq == 0 && Instant::now() - start > time
+        /// Parse the the input while calling the `predicate` callback every
+        /// `delta` time. Keep parsing until the callback returns `false` or we
+        /// reach the end of the input. If we stopped due to the callback,
+        /// return the current progress as `Some`. Otherwise, if we are at the
+        /// end, return `None`. After this function returns, use
+        /// [`parser`](Self::parser) to retrieve the parser state.
+        pub async fn process_check_every(
+            &mut self,
+            delta: Duration,
+            mut predicate: impl FnMut(&Parser, ReaderState) -> bool,
+        ) -> Option<ReaderState> {
+            // Calling `Instant::now` between each line can get expensive, so
+            // we'll try to avoid it. We will try to check every
+            // `MAX_LINES_PER_TIME_VARIATION * time_left`, ensuring that we
+            // never go over time as long as the lines-per-time of the parser
+            // does not drop by more than `MAX_TIME_OVER_APPROX` between checks.
+            // The closer this is to `1`, the fewer checks we'll do.
+            const MAX_LINES_PER_TIME_VARIATION: u128 = 10;
+            let initial_lines_per_check = delta.as_millis().try_into().unwrap_or(usize::MAX).max(10);
+            // How many lines must pass before we check time again?
+            let mut lines_per_check = initial_lines_per_check;
+            // How many lines until the next time check?
+            let mut next_check = lines_per_check;
+            let max_lpc = lines_per_check.checked_mul(1000).unwrap_or(usize::MAX);
+            let mut start = Instant::now();
+            let mut last_check_time = start;
+            add_await([self.process_until(move |p, rs| {
+                next_check -= 1;
+                if next_check == 0 {
+                    let now = Instant::now();
+                    match delta.checked_sub(now - start) {
+                        Some(time_left) if !time_left.is_zero() => {
+                            let time_left = time_left.as_nanos();
+                            let check_delta = (now - last_check_time).as_nanos();
+                            last_check_time = now;
+                            if check_delta < MAX_LINES_PER_TIME_VARIATION {
+                                lines_per_check = 1;
+                            } else {
+                                let check_delta = check_delta.checked_mul(MAX_LINES_PER_TIME_VARIATION).unwrap_or(u128::MAX);
+                                // How much smaller is `lines_per_check` than it
+                                // should be?
+                                let under_approx = (time_left / check_delta)
+                                    .try_into()
+                                    .unwrap_or(usize::MAX)
+                                    .max(1);
+                                // Do rounding up division to make sure
+                                // `over_approx > 1` as soon as `check_delta >
+                                // time_left`.
+                                let over_approx = (check_delta + time_left - 1) / time_left;
+                                // How much larger is `lines_per_check` than it
+                                // should be?
+                                let over_approx = over_approx
+                                    .try_into()
+                                    .unwrap_or(usize::MAX)
+                                    .max(1);
+                                let new_lpc = (lines_per_check * under_approx) / over_approx;
+                                lines_per_check = new_lpc.min(max_lpc).max(1);
+                            }
+                            next_check = lines_per_check;
+                        }
+                        _ => {
+                            // Out of time, reset to initial values and call
+                            // the predicate.
+                            lines_per_check = initial_lines_per_check;
+                            next_check = lines_per_check;
+                            start = now;
+                            last_check_time = now;
+                            return predicate(p, rs);
+                        }
+                    }
+                }
+                true
             })])
         }
-    
-        /// Parse the entire file as a stream. Using [`process_all_timeout`] instead is
-        /// recommended as this method will cause the process to hang if given a very large file.
+
+        /// Parse the entire file as a stream. Using [`process_all_timeout`]
+        /// instead is recommended as this method will cause the process to hang
+        /// if given a very large file.
         pub async fn process_all(mut self) -> Parser {
-            add_await([self.process_until(|_, _| false)]).unwrap()
+            add_await([self.process_until(|_, _| true)]);
+            self.parser
         }
-        /// Try to parse everything, but stop after a given timeout. The result tuple
-        /// contains `true` if the timeout was reached, and the parser state at the end (i.e. the
-        /// state is complete only if `false` was returned).
+        /// Try to parse everything, but stop after a given timeout. The result
+        /// tuple contains `Some(read_info)` if the timeout was reached, and the
+        /// parser state at the end (i.e. the state is complete only if `None`
+        /// was returned).
         ///
-        /// Parsing cannot be resumed if the timeout is reached. If you need support for resuming,
-        /// use [`process_for`] or [`process_until`] instead.
-        pub async fn process_all_timeout(mut self, timeout: Duration) -> (bool, Parser) {
-            let result = add_await([self.process_for(timeout)]);
-            (result.is_none(), result.unwrap_or_else(|| self.parser.unwrap()))
+        /// Parsing cannot be resumed if the timeout is reached. If you need
+        /// support for resuming, use [`process_check_every`] or
+        /// [`process_until`] instead.
+        pub async fn process_all_timeout(mut self, timeout: Duration) -> (Option<ReaderState>, Parser) {
+            let result = add_await([self.process_check_every(timeout, |_, _| false)]);
+            (result, self.parser)
         }
     }
 }

--- a/smt-log-parser/src/parsers/z3/mod.rs
+++ b/smt-log-parser/src/parsers/z3/mod.rs
@@ -26,10 +26,7 @@ impl<T: Z3LogParser + Default> LogParser for T {
             "[new-match]" => self.new_match(split, line_no),
             "[inst-discovered]" => self.inst_discovered(split, line_no),
             "[instance]" => self.instance(split, line_no),
-            "[end-of-instance]" => {
-                self.end_of_instance();
-                Some(())
-            }
+            "[end-of-instance]" => self.end_of_instance(split),
             "[decide-and-or]" => self.decide_and_or(split),
             "[decide]" => self.decide(split),
             "[assign]" => self.assign(split),
@@ -65,7 +62,7 @@ pub trait Z3LogParser: Debug {
     fn new_match(&mut self, l: Split<'_, char>, line_no: usize) -> Option<()>;
     fn inst_discovered(&mut self, l: Split<'_, char>, line_no: usize) -> Option<()>;
     fn instance(&mut self, l: Split<'_, char>, line_no: usize) -> Option<()>;
-    fn end_of_instance(&mut self);
+    fn end_of_instance(&mut self, l: Split<'_, char>) -> Option<()>;
 
     // unused in original parser
     fn decide_and_or(&mut self, _l: Split<'_, char>) -> Option<()> {

--- a/smt-log-parser/src/parsers/z3/z3parser.rs
+++ b/smt-log-parser/src/parsers/z3/z3parser.rs
@@ -7,6 +7,8 @@ use crate::{
     parsers::z3::{VersionInfo, Z3LogParser},
 };
 
+/// A parser for Z3 log files. Use one of the various `Z3Parser::from_*` methods
+/// to construct this parser.
 #[derive(Debug)]
 pub struct Z3Parser {
     pub(super) version_info: Option<VersionInfo>,
@@ -532,7 +534,7 @@ impl Z3LogParser for Z3Parser {
         Some(())
     }
 
-    fn end_of_instance(&mut self) {
+    fn end_of_instance(&mut self, mut l: Split<'_, char>) -> Option<()> {
         let iidx = self.inst_stack.pop().unwrap();
         let inst = &mut self.instantiations[iidx];
         let deps = self.temp_dependencies.get_mut(&inst.match_line_no).unwrap();
@@ -541,6 +543,9 @@ impl Z3LogParser for Z3Parser {
             dep.quant = inst.quant;
         });
         self.dependencies.append(deps);
+
+        // Return if there is unexpectedly more data
+        l.next().map_or(Some(()), |_| None)
     }
 }
 


### PR DESCRIPTION
Sorry for all the PRs. This should be the final one and should not break things too much. The `smt-log-parser/src/parsers/mod.rs` file is now final and should not need to be changed. I would recommend using the `process_check_every` function rather than `process_until`, that way you can even e.g. update the UI within the callback if you set the `Duration` high enough. All functions should have rather descriptive comment documentation.