### PR TITLE
Adding InstIdx to Dependency

### DIFF
--- a/axiom-profiler-GUI/src/svg_result.rs
+++ b/axiom-profiler-GUI/src/svg_result.rs
@@ -58,7 +58,11 @@ impl Component for SVGResult {
                 true
             },
             Msg::SelectedNodeIndex(index) => {
-                log::debug!("{index}");
+                if let Some(inst) = self.inst_graph.get_instantiation_info(index) {
+                    log::debug!("Got some instantiation with {}", inst.line_no.unwrap());
+                } else {
+                    log::debug!("Didn't get an instantiation");
+                }
                 false
             }
         }

--- a/smt-log-parser/src/items.rs
+++ b/smt-log-parser/src/items.rs
@@ -423,6 +423,7 @@ pub enum DepType {
 pub struct Dependency {
     pub from: usize,
     pub to: Option<usize>,
+    pub to_iidx: Option<InstIdx>,
     pub blamed: Option<TermIdx>,
     pub dep_type: DepType,
     pub quant: QuantIdx,

--- a/smt-log-parser/src/parsers/z3/z3parser.rs
+++ b/smt-log-parser/src/parsers/z3/z3parser.rs
@@ -542,6 +542,7 @@ impl Z3LogParser for Z3Parser {
         let deps = self.temp_dependencies.get_mut(&inst.match_line_no).unwrap();
         deps.iter_mut().for_each(|dep| {
             dep.to = inst.line_no;
+            dep.to_iidx = Some(iidx);
             dep.quant = inst.quant;
         });
         self.dependencies.append(deps);
@@ -584,6 +585,7 @@ impl Z3Parser {
         let dep = Dependency {
             from: match_line,
             to: None,
+            to_iidx: None,
             blamed: None,
             dep_type: DepType::None,
             quant,
@@ -611,6 +613,7 @@ impl Z3Parser {
             let dep = Dependency {
                 from: instantiation.line_no.unwrap(),
                 to: None,
+                to_iidx: None,
                 blamed: Some(from_term),
                 dep_type,
                 quant: instantiation.quant,


### PR DESCRIPTION
This is a suggestion to add a field `to_iidx: InstIdx` to `Dependency` in items.rs and changing the parser accordingly.