### PR TITLE
Fix parsing issues and a performance issue

### DIFF
--- a/smt-log-parser/src/parsers/z3/inst_graph.rs
+++ b/smt-log-parser/src/parsers/z3/inst_graph.rs
@@ -337,15 +337,9 @@ impl InstGraph {
         }
     }
 
-    fn fresh_line_nr(&self, line_nr: usize) -> bool {
-        self.inst_graph
-            .node_weights()
-            .all(|node| node.line_nr != line_nr)
-    }
-
     fn add_node(&mut self, node_data: NodeData) {
         let line_nr = node_data.line_nr;
-        if self.fresh_line_nr(line_nr) {
+        if !self.node_of_line_nr.contains_key(&line_nr) {
             let node = self.inst_graph.add_node(node_data);
             self.orig_graph.add_node(node_data);
             self.node_of_line_nr.insert(line_nr, node);

--- a/smt-log-parser/src/parsers/z3/mod.rs
+++ b/smt-log-parser/src/parsers/z3/mod.rs
@@ -10,12 +10,18 @@ pub mod z3parser;
 // pub mod dump;
 
 impl<T: Z3LogParser + Default> LogParser for T {
+    fn is_line_start(&mut self, first_byte: u8) -> bool {
+        first_byte == b'['
+    }
+
     fn process_line(&mut self, line: &str, line_no: usize) -> bool {
         // Much faster than `split_whitespace` or `split(' ')` since it works on
         // [u8] instead of [char] and so doesn't need to convert to UTF-8.
         let mut split = line.split_ascii_whitespace();
-        // println!("Processing {line:?} ({line_no})");
-        let parse = match split.next().unwrap() {
+        let Some(first) = split.next() else {
+            return true;
+        };
+        let parse = match first {
             // match the line case
             "[tool-version]" => self.version_info(split),
             "[mk-quant]" | "[mk-lambda]" => self.mk_quant(split),


### PR DESCRIPTION
It turns out that the logfile can contain multiline entries, e.g. in the `z3 v4.8.7` one sent [here](https://prusti.zulipchat.com/#narrow/stream/392436-viper-support/topic/axiom-profiler/near/404468234) at line 15716 there is the entry
```
[assign] #7690 clause p49 (not p50)
  (and (not (= $allocated val)) (not (= $allocated init)) (not (= $allocated rel)) (not (= $allocated acq)) (not (= val init)) (not (= val rel)) (not (= val acq)) (not (= init rel)) (not (= init acq)) (not (= rel acq))) 
  (not (distinct $allocated val init rel acq)) 
```
These are now handeled.